### PR TITLE
ci(winget): remove `version` input

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -11,5 +11,4 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: aiko-chan-ai.DiscordBotClient
-          version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
`version` input should be removed if you wish to keep the `v` prefix in tags (which you have added since [`v3.1.0`](https://github.com/aiko-chan-ai/DiscordBotClient/releases/tag/v3.1.0))