### PR TITLE
fix: persist per-guild member bio so the bot client re-displays it

### DIFF
--- a/src/AppCore/routes/guilds/#id/profile/index.ts
+++ b/src/AppCore/routes/guilds/#id/profile/index.ts
@@ -201,8 +201,9 @@ const callbackEditCurrentMember = (
         body: JSON.stringify(body),
     })
         .then(r => r.json() as Promise<APIGuildMember>)
-        .then(d =>
-            resCallback.send({
+        .then(d => {
+            if ("bio" in body) Util.setGuildMemberBio(guildId, (body.bio as string) || "");
+            return resCallback.send({
                 guild_id: guildId,
                 pronouns: "",
                 bio: body.bio || "",
@@ -212,8 +213,8 @@ const callbackEditCurrentMember = (
                 popout_animation_particle_type: null,
                 emoji: null,
                 profile_effect: null,
-            }),
-        )
+            });
+        })
         .catch(err => {
             console.error("Error in /guilds/:id/profile PATCH (member):", err);
             if (!resCallback.headersSent) resCallback.status(500).send({ message: "Internal Server Error", code: 500 });

--- a/src/AppCore/routes/guilds/#id/profile/index.ts
+++ b/src/AppCore/routes/guilds/#id/profile/index.ts
@@ -186,6 +186,7 @@ const callbackEditCurrentMember = (
     resCallback: Response,
 ) => {
     const guildId = reqCallback.params.id;
+    const botId = Util.getIDFromToken(reqCallback.headers.authorization);
     const body: Record<string, unknown> = {};
     if ("nick" in reqCallback.body) body.nick = reqCallback.body.nick;
     if ("avatar" in reqCallback.body) body.avatar = reqCallback.body.avatar;
@@ -202,7 +203,7 @@ const callbackEditCurrentMember = (
     })
         .then(r => r.json() as Promise<APIGuildMember>)
         .then(d => {
-            if ("bio" in body) Util.setGuildMemberBio(guildId, (body.bio as string) || "");
+            if ("bio" in body && botId) Util.setGuildMemberBio(botId, guildId, (body.bio as string) || "");
             return resCallback.send({
                 guild_id: guildId,
                 pronouns: "",

--- a/src/AppCore/routes/users/#id/profile.ts
+++ b/src/AppCore/routes/users/#id/profile.ts
@@ -28,7 +28,8 @@ app.get("/", async (req: Request<{ id: string }>, res) => {
             .catch(() => null);
     }
     let bio = null;
-    if (req.params.id === Util.getIDFromToken(req.headers.authorization)) {
+    const botId = Util.getIDFromToken(req.headers.authorization);
+    if (req.params.id === botId) {
         // Using bio from applications/@me
         const applicationData = await net.fetch(
             "https://canary.discord.com/api/v9/applications/@me",
@@ -51,7 +52,7 @@ app.get("/", async (req: Request<{ id: string }>, res) => {
     })
         .then(r => r.json() as Promise<APIUser>)
         .then(d =>
-            res.send(Util.ProfilePatch(d, guild_member, (guild_id as string) ?? null, bio)),
+            res.send(Util.ProfilePatch(d, guild_member, (guild_id as string) ?? null, bio, botId)),
         )
         .catch(err => {
             console.error("Error fetching user profile (/:id):", err);

--- a/src/AppCore/routes/users/@me/profile.ts
+++ b/src/AppCore/routes/users/@me/profile.ts
@@ -64,7 +64,7 @@ app.get(
             } as Record<string, string>,
         })
             .then(r => r.json() as Promise<APIUser>)
-            .then(d => res.send(Util.ProfilePatch(d, guild_member, guild_id, applicationBio)))
+            .then(d => res.send(Util.ProfilePatch(d, guild_member, guild_id, applicationBio, id)))
             .catch(err => {
                 console.error("Error fetching user profile (@me):", err);
                 if (!res.headersSent) res.status(500).send({ message: "Internal Server Error" });

--- a/src/AppUtils/Utils.ts
+++ b/src/AppUtils/Utils.ts
@@ -12,6 +12,12 @@ import { UserFlagsBitField } from "./DiscordBitField";
 import { BadgesBasedUserDataAndExtends as UserBadges } from "./UserBadges";
 
 export default class Util {
+    static guildMemberBios = new Map<string, string>();
+
+    static setGuildMemberBio (guildId: string, bio: string) {
+        Util.guildMemberBios.set(guildId, bio);
+    }
+
     static ProfilePatch (
         userData: APIUser,
         guildMember: APIGuildMember | null = null,
@@ -67,7 +73,7 @@ export default class Util {
             guild_member_profile: guildMember && {
                 guild_id: guildId,
                 pronouns: "",
-                bio: "",
+                bio: (guildId && Util.guildMemberBios.get(guildId)) || "",
                 banner: guildMember.banner,
                 accent_color: null,
                 theme_colors: null,

--- a/src/AppUtils/Utils.ts
+++ b/src/AppUtils/Utils.ts
@@ -14,8 +14,8 @@ import { BadgesBasedUserDataAndExtends as UserBadges } from "./UserBadges";
 export default class Util {
     static guildMemberBios = new Map<string, string>();
 
-    static setGuildMemberBio (guildId: string, bio: string) {
-        Util.guildMemberBios.set(guildId, bio);
+    static setGuildMemberBio (botId: string, guildId: string, bio: string) {
+        Util.guildMemberBios.set(`${botId}:${guildId}`, bio);
     }
 
     static ProfilePatch (
@@ -23,6 +23,7 @@ export default class Util {
         guildMember: APIGuildMember | null = null,
         guildId: string | null = null,
         bio: string | null = null,
+        botId: string | null = null,
     ) {
         const flags = new UserFlagsBitField(userData.flags);
         const badges: object[] = [];
@@ -73,7 +74,7 @@ export default class Util {
             guild_member_profile: guildMember && {
                 guild_id: guildId,
                 pronouns: "",
-                bio: (guildId && Util.guildMemberBios.get(guildId)) || "",
+                bio: (botId && guildId && Util.guildMemberBios.get(`${botId}:${guildId}`)) || "",
                 banner: guildMember.banner,
                 accent_color: null,
                 theme_colors: null,


### PR DESCRIPTION
Util.ProfilePatch() always returned guild_member_profile.bio as an empty string, so any bio set via PATCH /guilds/:id/members/@me was never shown again once the profile was re-fetched (fixes #330).

Cache the bio locally when the PATCH succeeds and read it back when building the profile response.