### PR TITLE
fix: handle applicationData fetch failure in users/:id profile route

### DIFF
--- a/src/AppCore/routes/users/#id/profile.ts
+++ b/src/AppCore/routes/users/#id/profile.ts
@@ -43,20 +43,24 @@ app.get("/", async (req: Request<{ id: string }>, res) => {
                 .catch(() => null);
         }
     }
-    let bio = null;
+    let bio: string | null = null;
     if (isCurrentUser) {
         // Using bio from applications/@me
-        const applicationData = await net
-            .fetch("https://canary.discord.com/api/v9/applications/@me", {
-                headers: {
-                    Authorization: req.headers.authorization,
-                    "User-Agent": Constants.UserAgentDiscordBot,
-                } as Record<string, string>,
-            })
-            .then(resF => {
-                return resF.json() as Promise<APIApplication>;
-            });
-        bio = applicationData.description;
+        try {
+            const applicationData = await net
+                .fetch("https://canary.discord.com/api/v9/applications/@me", {
+                    headers: {
+                        Authorization: req.headers.authorization,
+                        "User-Agent": Constants.UserAgentDiscordBot,
+                    } as Record<string, string>,
+                })
+                .then(resF => {
+                    return resF.json() as Promise<APIApplication>;
+                });
+            bio = applicationData.description;
+        } catch (err) {
+            console.error("Error fetching application data:", err);
+        }
     }
     net.fetch("https://canary.discord.com/api/v9/users/" + req.params.id, {
         headers: {


### PR DESCRIPTION
### Summary
Added error handling around the `/applications/@me` fetch in `src/AppCore/routes/users/#id/profile.ts`.

If that call failed, it threw an unhandled rejection and dropped the request without a response. This matches the same `try/catch` error handling already used in `users/@me/profile.ts`.
