### PR TITLE
fix(security): bind internal API and editor servers to loopback

### DIFF
--- a/src/AppCore/APIServer.ts
+++ b/src/AppCore/APIServer.ts
@@ -93,7 +93,7 @@ export default async function startAppServer (): Promise<number> {
             resolve(address.port);
             logger.log(`API Server listening on https://localhost:${address.port}`);
         };
-        server.listen(0).once("listening", callback);
+        server.listen(0, "127.0.0.1").once("listening", callback);
         server.on("error", reject);
     });
 }

--- a/src/AppCore/MessageEditorServer.ts
+++ b/src/AppCore/MessageEditorServer.ts
@@ -26,7 +26,7 @@ app.use(express.static(Constants.EditorHTMLFolderPath));
 
 export default async function startEditor (): Promise<number> {
     return new Promise((resolve, reject) => {
-        const server = app.listen(0, () => {
+        const server = app.listen(0, "127.0.0.1", () => {
             const { port } = server.address() as AddressInfo;
             resolve(port);
             logger.log(`API Server listening on http://localhost:${port}`);


### PR DESCRIPTION
### Summary
This PR restricts the internal Express API server and Message Editor static server to listen exclusively on the local loopback interface (`127.0.0.1`).

### Impact
`server.listen(0)` does not constrain the listener to loopback; in the affected runtime, the server was reachable through the LAN-facing interface. Other devices on the same local network could query internal endpoints (such as `/api/v9/users/@me/settings-proto/*`) and access or modify local settings.

### Root Cause
In `src/AppCore/APIServer.ts` and `src/AppCore/MessageEditorServer.ts`, `server.listen(0)` / `app.listen(0)` omitted an explicit host parameter, allowing incoming connections from non-loopback network interfaces.

### Fix
Explicitly pass `"127.0.0.1"` to `server.listen(0, "127.0.0.1")` in `APIServer.ts` and `app.listen(0, "127.0.0.1")` in `MessageEditorServer.ts`.

### Validation
- Validated with `npm run test:typescript` and `npm run build:ts`.
- Verified at runtime on a live instance:
  - `curl -k https://127.0.0.1:<port>/ping` -> `HTTP 200 OK`
  - `curl -k --connect-timeout 2 https://<LAN_IP>:<port>/ping` -> Connection timed out / refused
- Verified that bot login, Discord gateway connection, and channel message synchronization function normally.
